### PR TITLE
Fix crash with params x/y of wrong datatype.

### DIFF
--- a/tools/gcompris_shapegame.py
+++ b/tools/gcompris_shapegame.py
@@ -109,6 +109,10 @@ def gcompris_puzzle(img, sdrawable, x, y, activity_name,
     if(not activity_name):
         activity_name = "paintings"
 
+    # make float to int
+    x = int(x)
+    y = int(y)
+
     # Init
     bg_layer = img.active_layer
     pdb.gimp_selection_none(img)


### PR DESCRIPTION
The functionparameters x and y are sometimes float instead of int.
This leads to a crash at "xrange(y)" in the code below. This happens
for example with GIMP v2.6.12 and python v2.7.3 on a gentoo linux
system. Since x and y are always integer values - the spinners
configuration won't allow other values - we can safely convert to int
here.
