### PR TITLE
Fix missing note_names.py in Makefile.am

### DIFF
--- a/src/note_names-activity/Makefile.am
+++ b/src/note_names-activity/Makefile.am
@@ -1,6 +1,11 @@
 # Passthrough, do not break uplevel make rule
 install-activity:
 
+
+pythondir = $(PYTHON_PLUGIN_DIR)
+
+dist_python_DATA = note_names.py
+
 xmldir = $(pkgdatadir)/@PACKAGE_DATA_DIR@
 
 xml_in_files = \


### PR DESCRIPTION
The Makefile did not include "note_names.py" so it finally got not
installed. Without this pyhton module, the activity "Name that Note!"
does not work.

This issue is also discussed on the mailing list:
http://sourceforge.net/mailarchive/forum.php?thread_name=CACg2K7-qNmFmddsEm3LuOGOrrptniExRgQBywDSVtmB5eJpN5Q%40mail.gmail.com&forum_name=gcompris-devel
