### PR TITLE
fix: missing wav-files in Makefile.am

### DIFF
--- a/src/piano_composition-activity/resources/piano_composition/treble_pitches/Makefile.am
+++ b/src/piano_composition-activity/resources/piano_composition/treble_pitches/Makefile.am
@@ -12,7 +12,10 @@ img1_DATA = \
 	1/5.wav \
 	1/6.wav \
 	1/7.wav \
-	1/8.wav
+	1/8.wav \
+	1/9.wav \
+	1/10.wav \
+	1/11.wav
 
 img2dir = $(pkgdatadir)/@PACKAGE_DATA_DIR@/piano_composition/treble_pitches/2
 img2_DATA = \
@@ -28,7 +31,10 @@ img2_DATA = \
 	2/5.wav \
 	2/6.wav \
 	2/7.wav \
-	2/8.wav
+	2/8.wav \
+	2/9.wav \
+	2/10.wav \
+	2/11.wav
 
 img4dir = $(pkgdatadir)/@PACKAGE_DATA_DIR@/piano_composition/treble_pitches/4
 img4_DATA = \
@@ -37,6 +43,7 @@ img4_DATA = \
 	4/-3.wav \
 	4/-4.wav \
 	4/-5.wav \
+	4/-6.wav \
 	4/1.wav \
 	4/2.wav \
 	4/3.wav \
@@ -44,7 +51,10 @@ img4_DATA = \
 	4/5.wav \
 	4/6.wav \
 	4/7.wav \
-	4/8.wav
+	4/8.wav \
+	4/9.wav \
+	4/10.wav \
+	4/11.wav
 
 img8dir = $(pkgdatadir)/@PACKAGE_DATA_DIR@/piano_composition/treble_pitches/8
 img8_DATA = \
@@ -53,6 +63,7 @@ img8_DATA = \
 	8/-3.wav \
 	8/-4.wav \
 	8/-5.wav \
+	8/-6.wav \
 	8/1.wav \
 	8/2.wav \
 	8/3.wav \
@@ -60,6 +71,9 @@ img8_DATA = \
 	8/5.wav \
 	8/6.wav \
 	8/7.wav \
-	8/8.wav
+	8/8.wav \
+	8/9.wav \
+	8/10.wav \
+	8/11.wav
 
 EXTRA_DIST = $(img1_DATA) $(img2_DATA) $(img4_DATA) $(img8_DATA)


### PR DESCRIPTION
The wav files for "extended" tone have been added to the git repository,
since they are needed by certain melodies of the activity "piano
composition". But they have not been added to the make file, so they did
not get installed.

See also recent posts on mailing list.
