### PR TITLE
note_names: alternate solution for same-sound-bug

### DIFF
--- a/src/note_names-activity/note_names.py
+++ b/src/note_names-activity/note_names.py
@@ -344,11 +344,14 @@ They also form the C Major Scale. Notice that the note positions are different t
         y = 220
         random.shuffle(self.pitchPossibilities)
         for numID in self.pitchPossibilities:
-            drawNoteButton(x, y, numID, self.play_sound_on_click)
-            y += 30
-            if y > 320:
-                y = 220
-                x = x + 40
+            if numID != 8:
+                # do not draw another C-button, since this is ambiguous, because
+                # we have a c' and a c"
+                drawNoteButton(x, y, numID, self.play_sound_on_click)
+                y += 30
+                if y > 320:
+                    y = 220
+                    x = x + 40
 
     def play_sound_on_click(self, widget, target, event, numID):
         '''
@@ -357,6 +360,10 @@ They also form the C Major Scale. Notice that the note positions are different t
         self.selectedNoteObject = widget
 
         if self.pitchSoundEnabled:
+            # change the sound to be played to the c" sound, if we asked for a c"
+            # and the user clicked the c-button
+            if self.currentNote.numID == 8 and numID == 1:
+                numID = 8
             HalfNote(numID, self.staff.staffName, self.staff.rootitem).play()
         if hasattr(self, 'focusRect'):
             self.focusRect.remove()
@@ -384,7 +391,9 @@ They also form the C Major Scale. Notice that the note positions are different t
         self.timers.append(gobject.timeout_add(1500, self.readyToSoundAgain))
         g = self.selectedNoteObject.get_data('numID')
         c = self.currentNote.numID
-        if g == c:
+
+        # since we only have one c-button, the user has to click c' (=1) if c" (=8) is asked
+        if g == c or (c == 8 and g == 1):
             if not self.repeatThisNoteLaterPlease:
                 self.remainingNotesToIdentify.remove(c)
             if self.remainingNotesToIdentify == []:


### PR DESCRIPTION
Thanks for fixing the same-sound-bug. 

Looking at your fix, I came to following idea:

This commit reverts a2828a2ba35246c2c479a9d57ead58cbb815183b and
provides an alternate solution for the same-sound-bug in the note_names
activity.

We keep "show only one C-button" and just fix the same-sound-bug in
lines 363 following.

Reason:
At level 4 you don't get sounds, when clicking on the buttons.
So children don't have a chance do identify the correct solution.
Their only chance is to try one with a 50:50 chance of success. This
might be a little bit frustrating.

I have tested this 
- with the notes c', g' and c" 
- in levels 2, 3, 4, 5, 6, 12, 13, 15 and 16
- with and without the sharp notes, where applicable (there is no #c")
- checking for 
  - button sound matches asked note's sound
  - other buttons play different sounds
  - wrong answer detected as wrong answer
  - correct answer detected as correct answer

It seems to work quite well and children won't have to guess answers in
the case mentioned above.
But we have the nasty "if note == 8" again in the source.

What do you think?
