### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -177,7 +177,7 @@ dnl GCompris needs to know which locale are supported
 AC_SUBST(ALL_LINGUAS)
 AC_DEFINE_UNQUOTED(ALL_LINGUAS, "${ALL_LINGUAS}", [Supported languages])
 
-BUILD_DATE=`date +%y%m`
+BUILD_DATE=`date -r ChangeLog +%y%m`
 AC_DEFINE_UNQUOTED(BUILD_DATE,"$BUILD_DATE", [Date at which GCompris has been built])
 AC_SUBST(BUILD_DATE)
 


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.